### PR TITLE
fix: handle both __dirname and __filename undefined in getMeta function

### DIFF
--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -94,7 +94,7 @@ export function getMeta(metaUrl?: string): {
   __filename: string;
   __dirname: string;
 } {
-  const isESM = typeof __dirname === "undefined";
+  const isESM = typeof __dirname === "undefined" || typeof __filename === "undefined";
 
   if (isESM) {
     if (!metaUrl) {


### PR DESCRIPTION
For some reason lens was thinking my project is CJS, and was not working. From Node.js docs, adding both checks `__filename` or `__dirname` fixed it.

Ref: https://nodejs.org/api/esm.html#no-__filename-or-__dirname

Tested on: Node.js 22 LTS
OS: Linux