### PR TITLE
feat(watchers): add MikroORM query handler and logger support

### DIFF
--- a/.changeset/mikroorm-query-handler.md
+++ b/.changeset/mikroorm-query-handler.md
@@ -1,0 +1,5 @@
+---
+"@lensjs/watchers": minor
+---
+
+Add MikroORM query handler and logger support

--- a/packages/docs/handlers/query/express.md
+++ b/packages/docs/handlers/query/express.md
@@ -134,6 +134,47 @@ const sequelize = new Sequelize("DB_NAME", "DB_USER", "DB_PASSWORD", {
 });
 ```
 
+### 4. MikroORM
+
+Capture queries from **MikroORM** by using `createMikroOrmHandler` and `MikroOrmLensLogger`.
+
+**Dependencies:**
+
+```bash
+npm install @mikro-orm/core
+```
+
+**Usage Example (Express + MikroORM):**
+
+MikroORM integration requires two steps: (1) configure MikroORM with the Lens logger, and (2) register the query handler with lens.
+
+```ts
+import express from "express";
+import { lens } from "@lensjs/express";
+import { MikroORM } from "@mikro-orm/core";
+import { createMikroOrmHandler, MikroOrmLensLogger } from "@lensjs/watchers";
+
+const app = express();
+
+// Step 1: Configure MikroORM with the Lens logger
+const orm = await MikroORM.init({
+  debug: true, // Required: enables query logging
+  loggerFactory: (options) => new MikroOrmLensLogger(options),
+  // ... your other MikroORM options
+});
+
+// Step 2: Register the query watcher with lens
+await lens({
+  app,
+  queryWatcher: {
+    enabled: true,
+    handler: createMikroOrmHandler({ provider: "postgresql" }),
+  },
+});
+```
+
+> **Note:** MikroORM must be initialized with `debug: true` (or `debug: ["query"]`) for the Lens logger to receive query events. Transaction queries (`BEGIN`, `COMMIT`, `ROLLBACK`, `SAVEPOINT`) are automatically filtered out.
+
 ## Custom Handlers
 
 If your ORM or query client is not supported by the built-in handlers, you can create your own custom handler to integrate with Lens.
@@ -216,6 +257,6 @@ await lens({
 
 ## Summary
 
-- Use **built-in handlers** for Prisma, Kysely, and Sequelize  
+- Use **built-in handlers** for Prisma, Kysely, Sequelize, and MikroORM  
 - Or build a **custom handler** for your ORM/client  
 - All queries are automatically captured and displayed in the **Lens UI**

--- a/packages/docs/handlers/query/fastify.md
+++ b/packages/docs/handlers/query/fastify.md
@@ -134,6 +134,43 @@ const sequelize = new Sequelize("DB_NAME", "DB_USER", "DB_PASSWORD", {
 });
 ```
 
+### 4. MikroORM
+
+Capture queries from **MikroORM** by using `createMikroOrmHandler` and `MikroOrmLensLogger`.
+
+**Dependencies:**
+
+```bash
+npm install @mikro-orm/core
+```
+
+**Usage Example (Fastify + MikroORM):**
+
+```ts
+import Fastify from "fastify";
+import { lens } from "@lensjs/fastify";
+import { MikroORM } from "@mikro-orm/core";
+import { createMikroOrmHandler, MikroOrmLensLogger } from "@lensjs/watchers";
+
+const app = Fastify();
+
+// Step 1: Configure MikroORM with the Lens logger
+const orm = await MikroORM.init({
+  debug: true,
+  loggerFactory: (options) => new MikroOrmLensLogger(options),
+  // ... your other MikroORM options
+});
+
+// Step 2: Register the query watcher with lens
+await lens({
+  app,
+  queryWatcher: {
+    enabled: true,
+    handler: createMikroOrmHandler({ provider: "postgresql" }),
+  },
+});
+```
+
 ## Custom Handlers
 
 If your ORM or query client is not supported by the built-in handlers, you can create your own custom handler to integrate with Lens.
@@ -216,6 +253,6 @@ await lens({
 
 ## Summary
 
-- Use **built-in handlers** for Prisma, Kysely, and Sequelize  
+- Use **built-in handlers** for Prisma, Kysely, Sequelize, and MikroORM  
 - Or build a **custom handler** for your ORM/client  
 - All queries are automatically captured and displayed in the **Lens UI**

--- a/packages/docs/handlers/query/nestjs.md
+++ b/packages/docs/handlers/query/nestjs.md
@@ -182,9 +182,55 @@ To integrate Kysely with the Query Watcher, follow these steps:
     bootstrap();
     ```
 
-With these configurations, your NestJS application is now set up to use the Lens Query Watcher for Sequelize, Prisma, or Kysely, providing enhanced visibility into your database operations.
+With these configurations, your NestJS application is now set up to use the Lens Query Watcher for Sequelize, Prisma, Kysely, or MikroORM, providing enhanced visibility into your database operations.
 
-## 4. Custom Handlers
+## 4. MikroORM
+
+To integrate MikroORM with the Query Watcher, follow these steps:
+
+1.  **Installation:** Install MikroORM and its NestJS integration following the [official MikroORM documentation](https://mikro-orm.io/docs/guide/first-entity).
+
+2.  **Configure MikroORM Logging:** In your MikroORM configuration (e.g., `mikro-orm.config.ts`), set `debug: true` and provide the `MikroOrmLensLogger` as the `loggerFactory`.
+
+    ```ts
+    // mikro-orm.config.ts
+    import { defineConfig } from "@mikro-orm/postgresql";
+    import { MikroOrmLensLogger } from "@lensjs/watchers";
+
+    export default defineConfig({
+      debug: true, // Required: enables query logging
+      loggerFactory: (options) => new MikroOrmLensLogger(options),
+      // ... your other MikroORM options (entities, dbName, etc.)
+    });
+    ```
+
+3.  **Integrate with `main.ts`:** In your `main.ts` file, import `createMikroOrmHandler` from `@lensjs/watchers` and pass it to the `queryWatcher` configuration within the `lens` function.
+
+    ```ts
+    import { NestFactory } from "@nestjs/core";
+    import { AppModule } from "./app.module.js";
+    import { lens } from "@lensjs/nestjs";
+    import { createMikroOrmHandler } from "@lensjs/watchers";
+
+    async function bootstrap() {
+      const app = await NestFactory.create(AppModule);
+
+      await lens({
+        app,
+        queryWatcher: {
+          enabled: true,
+          handler: createMikroOrmHandler({ provider: "postgresql" }),
+        },
+      });
+
+      await app.listen(process.env.PORT ?? 3000);
+    }
+    bootstrap();
+    ```
+
+> **Note:** Transaction queries (`BEGIN`, `COMMIT`, `ROLLBACK`, `SAVEPOINT`) are automatically filtered out by the handler.
+
+## 5. Custom Handlers
 
 If your ORM or database client is not supported by the built-in handlers, you can create your own custom handler to integrate with Lens.
 

--- a/packages/handlers/package.json
+++ b/packages/handlers/package.json
@@ -34,9 +34,13 @@
     "emittery": "latest"
   },
   "peerDependencies": {
+    "@mikro-orm/core": "^6.0.0",
     "nodemailer": "^8.0.1"
   },
   "peerDependenciesMeta": {
+    "@mikro-orm/core": {
+      "optional": true
+    },
     "nodemailer": {
       "optional": true
     }

--- a/packages/handlers/src/query/index.ts
+++ b/packages/handlers/src/query/index.ts
@@ -1,3 +1,5 @@
 export * from "./prisma";
 export * from "./kysely";
 export { createSequelizeHandler } from "./sequelize";
+export { createMikroOrmHandler } from "./mikro-orm";
+export { MikroOrmLensLogger } from "./mikro-orm-logger";

--- a/packages/handlers/src/query/mikro-orm-logger.ts
+++ b/packages/handlers/src/query/mikro-orm-logger.ts
@@ -1,0 +1,48 @@
+import { DefaultLogger, type LoggerOptions, type LogContext } from "@mikro-orm/core";
+import { watcherEmitter } from "../utils/emitter";
+
+/**
+ * A MikroORM logger that bridges query events to Lens's watcherEmitter.
+ *
+ * Use this as the `loggerFactory` in your MikroORM configuration:
+ *
+ * ```ts
+ * import { MikroOrmLensLogger } from "@lensjs/watchers";
+ *
+ * const orm = await MikroORM.init({
+ *   debug: true,
+ *   loggerFactory: (options) => new MikroOrmLensLogger(options),
+ *   // ...
+ * });
+ * ```
+ *
+ * When debug mode is enabled, every query executed by MikroORM will be
+ * emitted as a `mikroOrmQuery` event on the `watcherEmitter`, which the
+ * `createMikroOrmHandler` listens to.
+ */
+export class MikroOrmLensLogger extends DefaultLogger {
+  constructor(options: LoggerOptions) {
+    super(options);
+  }
+
+  override logQuery(context: LogContext): void {
+    // Only emit when the logger is enabled (respects debug mode flags)
+    if (!this.isEnabled("query", context)) {
+      return;
+    }
+
+    const { query, params, took } = context;
+
+    if (query) {
+      watcherEmitter.emit("mikroOrmQuery", {
+        query,
+        params: params ?? [],
+        took,
+      });
+    }
+
+    // Optionally also call the parent implementation for console output
+    // Uncomment the line below if you want queries printed to console as well:
+    // super.logQuery(context);
+  }
+}

--- a/packages/handlers/src/query/mikro-orm.ts
+++ b/packages/handlers/src/query/mikro-orm.ts
@@ -1,0 +1,45 @@
+import { lensUtils } from "@lensjs/core";
+import { watcherEmitter } from "../utils/emitter";
+import { MikroOrmQueryType, QueryWatcherHandler } from "../types";
+import { nowISO } from "@lensjs/date";
+
+const TRANSACTION_QUERIES = ["BEGIN", "COMMIT", "ROLLBACK", "SAVEPOINT"];
+
+function shouldIgnoreQuery(query: string): boolean {
+  const trimmed = query.trim().toUpperCase();
+
+  return TRANSACTION_QUERIES.some((tq) => trimmed === tq || trimmed.startsWith(`${tq} `));
+}
+
+function getQueryObject({
+  provider,
+  payload,
+}: {
+  provider: MikroOrmQueryType;
+  payload: { query: string; params: unknown[]; took?: number };
+}) {
+  const sql = lensUtils.interpolateQuery(payload.query, payload.params ?? []);
+
+  return {
+    query: lensUtils.formatSqlQuery(sql, provider),
+    duration: `${payload.took?.toFixed(1) ?? "0.0"} ms`,
+    type: provider,
+    createdAt: nowISO(),
+  };
+}
+
+export function createMikroOrmHandler({
+  provider,
+}: {
+  provider: MikroOrmQueryType;
+}): QueryWatcherHandler {
+  return async ({ onQuery }) => {
+    watcherEmitter.on("mikroOrmQuery", (payload) => {
+      if (shouldIgnoreQuery(payload.query)) {
+        return;
+      }
+
+      onQuery(getQueryObject({ provider, payload }));
+    });
+  };
+}

--- a/packages/handlers/src/types/query.ts
+++ b/packages/handlers/src/types/query.ts
@@ -13,3 +13,8 @@ export type KyselyQueryType = Extract<
   SqlQueryType,
   "mysql" | "postgresql" | "sqlite" | "mssql"
 >;
+
+export type MikroOrmQueryType = Extract<
+  SqlQueryType,
+  "mysql" | "postgresql" | "sqlite" | "mariadb" | "tsql"
+>;

--- a/packages/handlers/src/utils/emitter.ts
+++ b/packages/handlers/src/utils/emitter.ts
@@ -4,5 +4,6 @@ import { createEmittery } from "@lensjs/core";
 export interface LensWatcherEvents {
   kyselyQuery: LogEvent;
   sequelizeQuery: { sql: string; timing?: number };
+  mikroOrmQuery: { query: string; params: unknown[]; took?: number };
 }
 export const watcherEmitter = createEmittery<LensWatcherEvents>();

--- a/packages/handlers/tests/mikro-orm.test.ts
+++ b/packages/handlers/tests/mikro-orm.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, vi, beforeEach, Mock } from "vitest";
+import { createMikroOrmHandler } from "../src/query/mikro-orm";
+import { watcherEmitter } from "../src/utils/emitter";
+import { lensUtils } from "@lensjs/core";
+
+// Mock dependencies — factories must be inline (no top-level vars) due to vi.mock hoisting
+vi.mock("../src/utils/emitter", () => ({
+  watcherEmitter: {
+    on: vi.fn(),
+  },
+}));
+
+vi.mock("@lensjs/core", () => ({
+  lensUtils: {
+    interpolateQuery: vi.fn(
+      (sql, params) => `interpolated(${sql}, ${JSON.stringify(params)})`,
+    ),
+    formatSqlQuery: vi.fn(
+      (sql, provider) => `formatted(${sql}, ${provider})`,
+    ),
+  },
+}));
+
+vi.mock("@lensjs/date", () => ({
+  nowISO: vi.fn(() => "2025-09-18T12:00:00.000Z"),
+}));
+
+describe("createMikroOrmHandler", () => {
+  let onQueryMock: Mock;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    onQueryMock = vi.fn();
+  });
+
+  it("should register a listener on watcherEmitter for mikroOrmQuery", async () => {
+    const handler = createMikroOrmHandler({ provider: "postgresql" });
+    await handler({ onQuery: onQueryMock });
+
+    expect(watcherEmitter.on).toHaveBeenCalledTimes(1);
+    expect(watcherEmitter.on).toHaveBeenCalledWith(
+      "mikroOrmQuery",
+      expect.any(Function),
+    );
+  });
+
+  it("should call onQuery with formatted data for a valid query", async () => {
+    const handler = createMikroOrmHandler({ provider: "postgresql" });
+    await handler({ onQuery: onQueryMock });
+
+    // Grab the registered listener
+    const listener = (watcherEmitter.on as Mock).mock.calls[0]![1];
+
+    const mikroOrmPayload = {
+      query: 'SELECT * FROM "users" WHERE "id" = ?',
+      params: [1],
+      took: 10.5,
+    };
+
+    await listener(mikroOrmPayload);
+
+    expect(lensUtils.interpolateQuery).toHaveBeenCalledWith(
+      mikroOrmPayload.query,
+      [1],
+    );
+    expect(lensUtils.formatSqlQuery).toHaveBeenCalledWith(
+      `interpolated(${mikroOrmPayload.query}, [1])`,
+      "postgresql",
+    );
+    expect(onQueryMock).toHaveBeenCalledTimes(1);
+    expect(onQueryMock).toHaveBeenCalledWith({
+      query: `formatted(interpolated(SELECT * FROM "users" WHERE "id" = ?, [1]), postgresql)`,
+      duration: "10.5 ms",
+      createdAt: "2025-09-18T12:00:00.000Z",
+      type: "postgresql",
+    });
+  });
+
+  it("should handle undefined took as '0.0 ms'", async () => {
+    const handler = createMikroOrmHandler({ provider: "sqlite" });
+    await handler({ onQuery: onQueryMock });
+
+    const listener = (watcherEmitter.on as Mock).mock.calls[0]![1];
+
+    await listener({
+      query: "SELECT 1",
+      params: [],
+    });
+
+    expect(onQueryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        duration: "0.0 ms",
+      }),
+    );
+  });
+
+  it("should handle undefined params as empty array", async () => {
+    const handler = createMikroOrmHandler({ provider: "mysql" });
+    await handler({ onQuery: onQueryMock });
+
+    const listener = (watcherEmitter.on as Mock).mock.calls[0]![1];
+
+    await listener({
+      query: "SELECT 1",
+      took: 2.0,
+    });
+
+    expect(lensUtils.interpolateQuery).toHaveBeenCalledWith("SELECT 1", []);
+    expect(onQueryMock).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(["BEGIN", "COMMIT", "ROLLBACK", "SAVEPOINT"])(
+    "should ignore %s transaction queries",
+    async (ignoredQuery) => {
+      const handler = createMikroOrmHandler({ provider: "postgresql" });
+      await handler({ onQuery: onQueryMock });
+
+      const listener = (watcherEmitter.on as Mock).mock.calls[0]![1];
+
+      await listener({
+        query: ignoredQuery,
+        params: [],
+        took: 1.0,
+      });
+
+      expect(onQueryMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it("should ignore parameterized transaction queries like 'SAVEPOINT xyz'", async () => {
+    const handler = createMikroOrmHandler({ provider: "mysql" });
+    await handler({ onQuery: onQueryMock });
+
+    const listener = (watcherEmitter.on as Mock).mock.calls[0]![1];
+
+    await listener({
+      query: "SAVEPOINT sp1",
+      params: [],
+      took: 0.5,
+    });
+
+    expect(onQueryMock).not.toHaveBeenCalled();
+  });
+
+  it("should NOT ignore non-transaction queries that merely contain a keyword as substring", async () => {
+    const handler = createMikroOrmHandler({ provider: "postgresql" });
+    await handler({ onQuery: onQueryMock });
+
+    const listener = (watcherEmitter.on as Mock).mock.calls[0]![1];
+
+    // "SELECT * FROM beginning_table" — contains "BEGIN" as substring
+    // but the filter checks for exact match or startsWith "BEGIN ",
+    // so this should pass through
+    await listener({
+      query: "SELECT * FROM beginning_table",
+      params: [],
+      took: 3.0,
+    });
+
+    expect(onQueryMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("should support all provider types", async () => {
+    const providers = [
+      "mysql",
+      "postgresql",
+      "sqlite",
+      "mariadb",
+      "tsql",
+    ] as const;
+
+    for (const provider of providers) {
+      vi.clearAllMocks();
+      onQueryMock = vi.fn();
+      const handler = createMikroOrmHandler({ provider });
+      await handler({ onQuery: onQueryMock });
+
+      const listener = (watcherEmitter.on as Mock).mock.calls[0]![1];
+      await listener({
+        query: "SELECT 1",
+        params: [],
+        took: 1.0,
+      });
+
+      expect(onQueryMock).toHaveBeenCalledWith(
+        expect.objectContaining({ type: provider }),
+      );
+    }
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -663,6 +663,9 @@ importers:
       '@lensjs/date':
         specifier: workspace:*
         version: link:../../shared/date
+      '@mikro-orm/core':
+        specifier: ^6.0.0
+        version: 6.6.16
       emittery:
         specifier: latest
         version: 1.2.0
@@ -2442,6 +2445,10 @@ packages:
 
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
+
+  '@mikro-orm/core@6.6.16':
+    resolution: {integrity: sha512-ym26fbhTti7Zh6oN1y74byoUoMEq1ahckiV7BZX5pHU/0OaUESiQA+Zar2Tv2ZFuZA9946XQ805F7/4NH6oDUQ==}
+    engines: {node: '>= 18.12.0'}
 
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
@@ -5242,6 +5249,9 @@ packages:
   data-uri-to-buffer@2.0.2:
     resolution: {integrity: sha512-ND9qDTLc6diwj+Xe5cdAgVTbLVdXbtxTJRXRhli8Mowuaan+0EJOtdqJ0QCHNSSPyoXGx9HX2/VMnKeC34AChA==}
 
+  dataloader@2.2.3:
+    resolution: {integrity: sha512-y2krtASINtPFS1rSDjacrFgn1dcUuoREVabwlOGOe4SdxenREqwjwjElAdwvbGM7kgZz9a3KVicWR7vcz8rnzA==}
+
   date-fns@1.30.1:
     resolution: {integrity: sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==}
 
@@ -5432,6 +5442,10 @@ packages:
 
   dotenv@17.2.3:
     resolution: {integrity: sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==}
+    engines: {node: '>=12'}
+
+  dotenv@17.3.1:
+    resolution: {integrity: sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==}
     engines: {node: '>=12'}
 
   dottie@2.0.6:
@@ -5951,6 +5965,10 @@ packages:
   fs-extra@10.1.0:
     resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
     engines: {node: '>=12'}
+
+  fs-extra@11.3.3:
+    resolution: {integrity: sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==}
+    engines: {node: '>=14.14'}
 
   fs-extra@7.0.1:
     resolution: {integrity: sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==}
@@ -7279,6 +7297,10 @@ packages:
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
+
+  mikro-orm@6.6.16:
+    resolution: {integrity: sha512-42bvve+XSzvBpOuZeZxJsM5aW4DQnDn23E5to4cvEjUdaPX7jg1bRh+l8f/8/WJJNzG1T05V5vHSe+SHzqN87A==}
+    engines: {node: '>= 18.12.0'}
 
   mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
@@ -11984,6 +12006,16 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
+  '@mikro-orm/core@6.6.16':
+    dependencies:
+      dataloader: 2.2.3
+      dotenv: 17.3.1
+      esprima: 4.0.1
+      fs-extra: 11.3.3
+      globby: 11.1.0
+      mikro-orm: 6.6.16
+      reflect-metadata: 0.2.2
+
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
       '@emnapi/core': 1.5.0
@@ -14810,6 +14842,8 @@ snapshots:
 
   data-uri-to-buffer@2.0.2: {}
 
+  dataloader@2.2.3: {}
+
   date-fns@1.30.1: {}
 
   dateformat@4.6.3: {}
@@ -14939,6 +14973,8 @@ snapshots:
   dotenv@17.2.1: {}
 
   dotenv@17.2.3: {}
+
+  dotenv@17.3.1: {}
 
   dottie@2.0.6: {}
 
@@ -15660,6 +15696,12 @@ snapshots:
   fs-constants@1.0.0: {}
 
   fs-extra@10.1.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.2.0
+      universalify: 2.0.1
+
+  fs-extra@11.3.3:
     dependencies:
       graceful-fs: 4.2.11
       jsonfile: 6.2.0
@@ -17245,6 +17287,8 @@ snapshots:
     dependencies:
       braces: 3.0.3
       picomatch: 2.3.1
+
+  mikro-orm@6.6.16: {}
 
   mime-db@1.52.0: {}
 


### PR DESCRIPTION
# MikroORM Query Watching for @lensjs/watchers

Adds native MikroORM query watching to `@lensjs/watchers`, following the same `watcherEmitter` pattern used by Kysely and Sequelize handlers.

## What's Included

- **`createMikroOrmHandler({ provider })`** — `QueryWatcherHandler` factory that listens on the emitter for `mikroOrmQuery` events, interpolates params, formats SQL, and filters transaction queries

- **`MikroOrmLensLogger`** — extends MikroORM's `DefaultLogger`, overriding `logQuery` to bridge query events to the emitter; used as `loggerFactory` in `MikroORM.init()`

- **11 unit tests** covering:
  - Handler registration
  - SQL formatting
  - Undefined-handling
  - Transaction filtering (exact + parameterized)
  - All supported providers

- **Documentation** for Express, Fastify, and NestJS adapters

- MikroORM v6+ is an optional peer dependency

## Usage

### Step 1: MikroORM Configuration

```typescript
const orm = await MikroORM.init({
  debug: true,
  loggerFactory: (options) => new MikroOrmLensLogger(options),
});
```

### Step 2: Lens Configuration

```typescript
await lens({
  app,
  queryWatcher: {
    enabled: true,
    handler: createMikroOrmHandler({ provider: "postgresql" }),
  },
});
```

## Supported Providers

- PostgreSQL
- MySQL
- SQLite
- MariaDB